### PR TITLE
Fix memory leak

### DIFF
--- a/SetTimeFromLocation/src/location_from_ip.c
+++ b/SetTimeFromLocation/src/location_from_ip.c
@@ -42,6 +42,9 @@ struct location_info* GetLocationData(void)
 		locationInfo.lat = lat;
 		locationInfo.lng = lng;
 
+		// Free the memory allocated by the call to json_parse_string()
+		json_value_free(rootProperties);
+		
 		// need to free data since this was allocated in the getHttpData function.
 		free(data);
 		return &locationInfo;


### PR DESCRIPTION
# Description

`json_parse_string()` allocates memory on the heap that must be freed by calling `json_value_free()`.

## Type of change

- Bug fix

# Checklist:

- [ ] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [ ] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [ ] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
