### PR TITLE
Update Program.cs

### DIFF
--- a/DeviceTenantFinder/Src/DeviceTenantFinder/Program.cs
+++ b/DeviceTenantFinder/Src/DeviceTenantFinder/Program.cs
@@ -85,7 +85,7 @@ namespace DeviceTenantFinder
                 Devices devices = JsonConvert.DeserializeObject<Devices>(result);
                 foreach (Item item in devices.Items)
                 {
-                    if (item.DeviceId == args[0])
+                    if (item.DeviceId.ToLower() == args[0].ToLower())
                     {
                         deviceFound = true;
                         tenantId = tenant.Id;


### PR DESCRIPTION
# Description

use .tolower() on command line supplied Device ID and REST API Device IDs to avoid case mismatch.

## Type of change

Please delete options that are not relevant.

- Bug fix

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [x] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [x] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
