### PR TITLE
SDCard update readme, target Avnet Starter Kit v2 as default

### DIFF
--- a/LittleFs_SDCard/README.md
+++ b/LittleFs_SDCard/README.md
@@ -42,6 +42,8 @@ Modify the TOTAL_BLOCKS definition to match the size of your SD Card - the defau
 #define TOTAL_BLOCKS   8192     // TODO: Modify TOTAL_BLOCKS to match your SD Card configuration (total bytes/512)
 ```
 
+**Note:** The project is configured to use the Avnet MT3620 Starter Kit Version 2 which uses ISU0 on Click Socket 1 and a [Mikroe SD Click board](https://www.mikroe.com/microsd-click). If you want to use the project with the Avnet MT3620 Starter Kit Version 1 you will need to modify the Real-Time applications app_manifest.json, and main.c to use ISU0. If you are using a stand-alone SD Card board such as the [AdaFruit SD Card breakout board](https://www.adafruit.com/product/254) and the Seeed RDB then you can choose an appropriate ISU.
+
 Note that you can increase the amount of debug information displayed from the High-Level and Real-Time Capable applications by uncommenting this line in CMakeLists.txt
 
 ```python

--- a/LittleFs_SDCard/src/AzureSphere/SDCard_HighLevelApp/main.c
+++ b/LittleFs_SDCard/src/AzureSphere/SDCard_HighLevelApp/main.c
@@ -317,7 +317,7 @@ void FormatCard(void)
     {
         if (SDCard_WriteBlock(x, &formatBuffer[0], BLOCK_SIZE) != LFS_ERR_OK)
         {
-            Log_Debug("\nFaied to write block %d\n", x);
+            Log_Debug("\nFailed to write block %d\n", x);
             break;
         }
     }

--- a/LittleFs_SDCard/src/AzureSphere/SDCard_RealTimeApp/app_manifest.json
+++ b/LittleFs_SDCard/src/AzureSphere/SDCard_RealTimeApp/app_manifest.json
@@ -5,7 +5,7 @@
   "EntryPoint": "/bin/app",
   "Capabilities": {
     "AllowedApplicationConnections": [ "25025d2c-66da-4448-bae1-ac26fcdd3627" ],
-    "SpiMaster": [ "ISU1" ]
+    "SpiMaster": [ "ISU0" ]
   },
   "ApplicationType": "RealTimeCapable"
 }

--- a/LittleFs_SDCard/src/AzureSphere/SDCard_RealTimeApp/main.c
+++ b/LittleFs_SDCard/src/AzureSphere/SDCard_RealTimeApp/main.c
@@ -289,8 +289,8 @@ _Noreturn void RTCoreMain(void)
     }
 
     // Open SPI 
-    // ISU1 was chosen so the code could run on the Avnet board with a Mikroe SD Card Click board and Adafruit SD Card board on the Seeed RDB
-    driver = SPIMaster_Open(MT3620_UNIT_ISU1);
+    // ISU0 was chosen so the code could run on the Avnet V2 board with a Mikroe SD Card Click board.
+    driver = SPIMaster_Open(MT3620_UNIT_ISU0);
     if (!driver) {
         UART_Print(debug,
             "ERROR: SPI initialisation failed\r\n");


### PR DESCRIPTION
# Description

Switch from ISU1 to ISU0 to support Click Socket 1 on the Avnet Starter Kit v2 as default. Fix spelling mistake in High Level App, update README

## Type of change

Please delete options that are not relevant.

- Update to existing content

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [x] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [x] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
