### PR TITLE
fix to devx license url

### DIFF
--- a/MQTT-C_Client/README.md
+++ b/MQTT-C_Client/README.md
@@ -106,4 +106,4 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 See [LICENSE.txt](./LICENSE.txt)
 
 - MQTT-C is included via a submodule. The license for MQTT-C can be [found here](https://github.com/LiamBindle/MQTT-C/blob/master/LICENSE).
-- AzureSphereDevX is include via a submodule. The license for AzureSphereDevX can be [found here](https://github.com/gloveboxes/AzureSphereDevX/blob/main/LICENSE).
+- AzureSphereDevX is include via a submodule. The license for AzureSphereDevX can be [found here](https://github.com/Azure-Sphere-DevX/AzureSphereDevX/blob/master/LICENSE).


### PR DESCRIPTION
# Description

Please include a summary of the change.

Fix of broken url to AzureSphereDevX

## Type of change

Please delete options that are not relevant.

- Update to existing content

# Checklist:

- [ ] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [ ] I have performed a self-review of my own contribution
- [ ] I have provided comments where appropriate
- [ ] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [ ] I have added/updated license(s) for this project as appropriate
- [ ] I have permission to publish this content (in case the content was collaborative)
- [ ] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
