### PR TITLE
Update DeviceTenantFinder to use Public API v2

### DIFF
--- a/DeviceTenantFinder/Src/DeviceTenantFinder/DeviceTenantFinder.csproj
+++ b/DeviceTenantFinder/Src/DeviceTenantFinder/DeviceTenantFinder.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.8.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.45.0" />
   </ItemGroup>
 
 </Project>

--- a/DeviceTenantFinder/Src/DeviceTenantFinder/Properties/launchSettings.json
+++ b/DeviceTenantFinder/Src/DeviceTenantFinder/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "DeviceTenantFinder": {
-      "commandName": "Project",
-      "commandLineArgs": ""
+      "commandName": "Project"
     }
   }
 }


### PR DESCRIPTION
# Description

DeviceTenantFinder updated to use the Azure Sphere Public API v2 endpoint and also remove dependencies on RestSharp and Newtonsoft.Json

## Type of change

Please delete options that are not relevant.

- Update to existing content

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [x] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [x] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
