### PR TITLE
Updated to use IoTC release APIs and align with the AzureIoT AppSampl…

### DIFF
--- a/SetIoTCentralPropsForDeviceGroup/README.md
+++ b/SetIoTCentralPropsForDeviceGroup/README.md
@@ -27,7 +27,9 @@ SetIoTCentralPropsForDeviceGroup is a console application, the application takes
 | `Azure IoT Central App URL`       | example: https://myapp.azureiotcentral.com |
 | `Azure IoT Central API Token` | [Create an API token in the IoT Central App](https://docs.microsoft.com/en-us/azure/iot-central/core/overview-iot-central-tour#administration) |
 | `Azure Sphere Device group guid`   | The guid of the Azure Sphere Device Group to update |
-| `JSON Setting to apply`       | example: {"StatusLED":true} |
+| `JSON File containing settings to apply`       | example: `{"thermometerTelemetryUploadEnable": true}` |
+
+**Note that the JSON property needs to be read/write in the Azure IoT Central Application.**
 
 To obtain the Azure Sphere Device Group ID you can:
 * Determine the list of Azure Sphere tenants you have access to `azsphere tenant list`

--- a/SetIoTCentralPropsForDeviceGroup/Src/SetIoTCentralPropsForDeviceGroup/IoTC_Settings.json
+++ b/SetIoTCentralPropsForDeviceGroup/Src/SetIoTCentralPropsForDeviceGroup/IoTC_Settings.json
@@ -1,0 +1,1 @@
+{ "thermometerTelemetryUploadEnabled": false }

--- a/SetIoTCentralPropsForDeviceGroup/Src/SetIoTCentralPropsForDeviceGroup/Properties/launchSettings.json
+++ b/SetIoTCentralPropsForDeviceGroup/Src/SetIoTCentralPropsForDeviceGroup/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "SetIoTCentralPropsForDeviceGroup": {
-      "commandName": "Project",
-      "commandLineArgs": ""
+      "commandName": "Project"
     }
   }
 }

--- a/SetIoTCentralPropsForDeviceGroup/Src/SetIoTCentralPropsForDeviceGroup/SetIoTCentralPropsForDeviceGroup.csproj
+++ b/SetIoTCentralPropsForDeviceGroup/Src/SetIoTCentralPropsForDeviceGroup/SetIoTCentralPropsForDeviceGroup.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.8.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.45.0" />
+    <PackageReference Include="RestSharp" Version="108.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…es project

# Description

The project has been updated to use the IoT Central released REST APIs (was using preview APIs), also aligned with the Azure Sphere 'AzureIoT' sample to use a read/write property as the example property to set.

## Type of change

Please delete options that are not relevant.

- Update to existing content

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [x] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [x] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
