### PR TITLE
Alstocks/get os version

### DIFF
--- a/GetDeviceOsVersion/LICENSE.txt
+++ b/GetDeviceOsVersion/LICENSE.txt
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/GetDeviceOsVersion/README.md
+++ b/GetDeviceOsVersion/README.md
@@ -1,0 +1,45 @@
+# Get device os version
+
+The goal of this project is to show how to get the OS version of an MT3620 device.
+
+## Contents
+
+| File/folder  | Description                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| `src\CSharp` | Contains the C# project and source files that demonstrate how to get the device OS version. |
+| `src\Python` | Contains the Python file that demonstrates how to get the device OS version.                |
+| `README.md`  | This README file.                                                                           |
+
+## Prerequisites & Setup
+
+- An Azure Sphere-based device with development features (see [Get started with Azure Sphere](https://azure.microsoft.com/en-us/services/azure-sphere/get-started/) for more information).
+- For the Python script, [install and/or upgrade  pip](https://pip.pypa.io/en/stable/installing/) and install [`azuresphere-device-api`](https://pypi.org/project/azuresphere-device-api/)
+- For the C# project, install [`Microsoft.Azure.Sphere.DeviceAPI`](https://www.nuget.org/packages/Microsoft.Azure.Sphere.DeviceAPI).
+
+
+## Project expectations
+
+* The code has been developed to show how to get the OS version of an MT3620 device, based on [the C#/Python package project](https://github.com/Azure/azure-sphere-samples/tree/main/Manufacturing) - It is not official, maintained, or production-ready code.
+
+### Expected support for the code
+
+This code is not formally maintained, but we will make a best effort to respond to/address any issues you encounter.
+
+### How to report an issue
+
+If you run into an issue with this code, please open a GitHub issue against this repo.
+
+## Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/GetDeviceOsVersion/src/CSharp/GetDeviceOsVersion.csproj
+++ b/GetDeviceOsVersion/src/CSharp/GetDeviceOsVersion.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Sphere.DeviceAPI" Version="0.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/GetDeviceOsVersion/src/CSharp/Program.cs
+++ b/GetDeviceOsVersion/src/CSharp/Program.cs
@@ -1,0 +1,118 @@
+﻿/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+using System.Text.Json;
+using Microsoft.Azure.Sphere.DeviceAPI;
+
+namespace GetDeviceOsVersion
+{
+    /// <summary>
+    /// A class containing the main functionality of the program.
+    /// </summary>
+    class Program
+    {
+        /// <summary>
+        /// The main entry point of the program that finds the OS version.
+        /// </summary>
+        static void Main()
+        {
+            // Get the list of attached devices IP addresses
+            List<DeviceInfo> devices = JsonSerializer.Deserialize<List<DeviceInfo>>(Devices.GetAttachedDevices());
+
+            // Get the list of Azure Sphere published OS images
+            Version[] versions = GetPublishedOSList();
+
+            foreach (DeviceInfo device in devices)
+            {
+                string OSVersion = GetOSVersion(versions, GetDeviceImages(GetDeviceImageList(device.IpAddress)));
+                Console.WriteLine($"Device IP = {device.IpAddress}, OS version = {OSVersion}");
+            }
+        }
+
+        /// <summary>
+        /// Get the Azure Sphere OS Versions and their Image and Component IDs.
+        /// </summary>
+        /// <returns>An array of OS versions and their Image and Component IDs.</returns>
+        private static Version[] GetPublishedOSList()
+        {
+            // Get the json containing the list of image and component IDs for each OS version.
+            string response = GetRequest("https://prod.releases.sphere.azure.net/versions/mt3620an.json");
+            PublishedOSList osList = JsonSerializer.Deserialize<PublishedOSList>(response);
+
+            return osList.versions;
+        }
+
+        /// <summary>
+        /// Gets a list of components installed on the device.
+        /// </summary>
+        /// <param name="deviceIp">The IP address of the device you would like to retrieve the image list from.</param>
+        /// <returns>The list of components running on the device.</returns>
+        private static Component[] GetDeviceImageList(string deviceIp)
+        {
+            Devices.SetActiveDeviceIpAddress(deviceIp);
+            string response = Image.GetImages();
+            DeviceImages deviceImages = JsonSerializer.Deserialize<DeviceImages>(response);
+
+            return deviceImages.components;
+        }
+
+        /// <summary>
+        /// Get a list of images on the device that are not applications.
+        /// </summary>
+        /// <param name="components">The array of components you would like to retrieve the device images from.</param>
+        /// <returns>The images with any applications filtered out.</returns>
+        private static Dictionary<string, string> GetDeviceImages(Component[] components)
+        {
+            Dictionary<string, string> images = new();
+            foreach (Component component in components)
+            {
+                // Image types https://docs.microsoft.com/rest/api/azure-sphere/image/get-metadata
+                if (component.image_type != 10)
+                {
+                    // Not an app.
+                    images.Add(component.name, component.uid);
+                }
+            }
+
+            return images;
+        }
+
+        /// <summary>
+        /// Gets the current OS Version for the device by matching device image IDs to the published OS Image IDs
+        /// </summary>
+        /// <param name="version">The OS versions you are comparing the device against.</param>
+        /// <param name="deviceImages">The device images running on your device.</param>
+        /// <returns>The OS version your device is running if found, otherwise an empty string.</returns>
+        private static string GetOSVersion(Version[] version, Dictionary<string, string> deviceImages)
+        {
+            // walk backwards up the OS image list
+            for (int x = version.Length - 1; x > -1; x--)
+            {
+                for (int y = 0; y < version[x].images.Length; y++)
+                {
+                    for (int z = 0; z < deviceImages.Count; z++)
+                    {
+                        if (version[x].images[y].cid == deviceImages[deviceImages.Keys.ToList()[z]])
+                        {
+                            return version[x].name;
+                        }
+                    }
+                }
+            }
+
+            return "Unknown";
+        }
+
+        /// <summary>
+        /// Makes a "GET" request to the given address.
+        /// </summary>
+        /// <param name="address">The address to make the "GET" request to.</param>
+        /// <returns>The content of the response, as a string.</returns>
+        private static string GetRequest(string address)
+        {
+            HttpResponseMessage response = new HttpClient().GetAsync(address).GetAwaiter().GetResult();
+
+            return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/GetDeviceOsVersion/src/CSharp/ResponseTypes.cs
+++ b/GetDeviceOsVersion/src/CSharp/ResponseTypes.cs
@@ -1,0 +1,55 @@
+﻿/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+namespace GetDeviceOsVersion
+{
+    // List of public OS versions/components
+    public class PublishedOSList
+    {
+        public Version[] versions { get; set; }
+    }
+    public class Version
+    {
+        public string name { get; set; }
+        public Images[] images { get; set; }
+    }
+    public class Images
+    {
+        public string cid { get; set; }
+        public string iid { get; set; }
+    }
+
+    // List of device components
+    public class DeviceImages
+    {
+        public bool is_ota_update_in_progress { get; set; }
+        public bool has_staged_updates { get; set; }
+        public bool restart_required { get; set; }
+        public Component[] components { get; set; }
+    }
+
+    public class Component
+    {
+        public string uid { get; set; }
+        public int image_type { get; set; }
+        public bool is_update_staged { get; set; }
+        public bool does_image_type_require_restart { get; set; }
+        public DeviceImage[] images { get; set; }
+        public string name { get; set; }
+    }
+
+    public class DeviceImage
+    {
+        public string uid { get; set; }
+        public int length_in_bytes { get; set; }
+        public int uncompressed_length_in_bytes { get; set; }
+        public int replica_type { get; set; }
+    }
+
+    // Similar to DeviceImage
+    public class DeviceInfo
+    {
+        public string IpAddress { get; set; }
+        public string ConnectionPath { get; set; }
+    }
+}

--- a/GetDeviceOsVersion/src/Python/get_device_os_version.py
+++ b/GetDeviceOsVersion/src/Python/get_device_os_version.py
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import requests
+from azuresphere_device_api import devices, image
+
+
+def get_device_os_version():
+    """The main entry point of the program that finds the OS version."""
+    # Get the list of attached devices IP addresses
+    attached_devices = devices.get_attached_devices()
+    
+    # Get the list of Azure Sphere published OS images
+    versions = _get_published_os_list()
+    
+    for device in attached_devices:
+        device_ip = device["IpAddress"]
+        os_version = _get_os_version(versions, _get_device_images(_get_device_image_list(device_ip)))
+        print(f"Device IP = {device_ip}, OS version = {os_version}")
+    
+def _get_published_os_list() -> list:
+    """Get the Azure Sphere OS Versions and their Image and Component IDs.
+
+    :returns: An array of OS versions and their Image and Component IDs.
+    :rtype: list
+    """
+    response = _get_request("https://prod.releases.sphere.azure.net/versions/mt3620an.json")
+    return response['versions']
+
+def _get_device_image_list(device_ip:str)-> list:
+    """Gets a list of components installed on the device.
+
+    :param device_ip: The IP address of the device you would like to retrieve the image list from.
+    :type device_ip: str
+    :returns: The list of components running on the device.
+    :rtype: list
+    """
+    devices.set_active_device_ip_address(device_ip)
+    response = image.get_images()
+    
+    return response['components']
+    
+def _get_device_images(components: list) -> dict:
+    """Get a list of images on the device that are not applications.
+
+    :param components: The array of components you would like to retrieve the device images from.
+    :type components: list
+    
+    :returns: The images with any applications filtered out.
+    :rtype: dict
+    """
+    images = {}
+    for component in components:
+        # Image types https://docs.microsoft.com/rest/api/azure-sphere/image/get-metadata
+        if component['image_type'] != 10:
+            images[component['name']] = component['uid']
+    
+    return images
+
+def _get_os_version(version:list, device_images:dict):
+    """Gets the current OS Version for the device by matching device image IDs to the published OS Image IDs.
+
+    :param version: The OS versions you are comparing the device against.
+    :type version: list
+    :param device_images: The device images running on your device.
+    :type device_images: dict
+    
+    :returns: The OS version your device is running if found, otherwise an empty string.
+    :rtype: str
+    """
+    device_images_key_list = list(device_images.keys())
+    for x in reversed(range(len(version))):
+        for y in range(len(version[x]['images'])):
+            for z in range(len(device_images)): 
+                if version[x]['images'][y]['cid'] == device_images[device_images_key_list[z]]:
+                    return version[x]['name']
+    
+    return ""
+
+def _get_request(address: str) -> str:
+    """Makes a "GET" request to the given address.
+
+    :param address: The address to make the "GET" request to.
+    :type address: str
+    
+    :returns: The content of the response, as a string.
+    :rtype: str
+    """
+    response = requests.get(address)
+    return response.json()
+
+get_device_os_version()

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Each folder within this repository contains a README.md file that describes the 
 | [AzureSphereTenantDeviceTwinSync](AzureSphereTenantDeviceTwinSync) | A project that shows how to update IoT Hub device twin with OS Version, Product/Device Group and more based on telemetry triggers using Azure IoT Hub/EventGrid and a custom ASP.NET Core REST API  |
 | [DeviceTenantFinder](DeviceTenantFinder) | Utility that makes it easy to find the Azure Sphere tenant name/Id within your tenants for a given Device Id |
 | [EAP-TLS_Solution](EAP-TLS_Solution) | A library & demo solution implementation for Azure Sphere-based devices connecting to Extensible Authentication Protocol – Transport Layer Security (EAP-TLS) networks. |
+| [GetDeviceOSVersion](GetDeviceOSVersion)| A project that retrieves the OS versions for all Azure Sphere based devices.|
 | [Grove_16x2_RGB_LCD](Grove_16x2_RGB_LCD) | A project that shows how to integrate a Seeed Grove LCD/RGB 16x2 display |
 | [HeapTracker](HeapTracker) | A memory allocation tracking library that can help diagnose memory leaks. |
 | [LittleFs_RemoteDisk](LittleFs_RemoteDisk) | A project that shows how to add [Littlefs](https://github.com/littlefs-project/littlefs) to an Azure Sphere project, uses Curl to talk to remote storage |


### PR DESCRIPTION
# Description

Adds GetOsVersion gallery sample. Pulls the device OS versions from azure, compares against the attached devices images to return each devices OS version.

## Type of change

- New content

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [x] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [x] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
