### PR TITLE
Add NIST time server as another fallback option

### DIFF
--- a/OSNetworkRequirementChecker-HLApp/src/ntp-helper.c
+++ b/OSNetworkRequirementChecker-HLApp/src/ntp-helper.c
@@ -8,11 +8,11 @@
 #define NTP_SERVER_LEN 256
 
 // List of time server to be tested
-const char *NTPServerList[] = { "168.61.215.74", "20.43.94.199", "20.189.79.72",
+const char *NTPServerList[] = { "168.61.215.74", "129.6.15.28", "20.43.94.199", "20.189.79.72",
                                 "40.81.94.65", "40.81.188.85", "40.119.6.228", "40.119.148.38",
                                 "20.101.57.9", "51.137.137.111", "51.145.123.29",
                                 "52.148.114.188", "52.231.114.183"};
-const unsigned int NTPServerListLen = 11;
+const unsigned int NTPServerListLen = 12;
 char **timeBeforeSyncList = NULL;
 char **timeAfterSyncList = NULL;
 int ntpIndex = 0;


### PR DESCRIPTION
# Description

Please include a summary of the change.

## Type of change

Please delete options that are not relevant.

- Bug fix
- Update to existing content
- New content

# Checklist:

- [ ] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [ ] I have performed a self-review of my own contribution
- [ ] I have provided comments where appropriate
- [ ] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [ ] I have added/updated license(s) for this project as appropriate
- [ ] I have permission to publish this content (in case the content was collaborative)
- [ ] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
