### PR TITLE
Fix an error about the doc string following the field name

### DIFF
--- a/Rust/cargo-azsphere/src/config/mod.rs
+++ b/Rust/cargo-azsphere/src/config/mod.rs
@@ -24,12 +24,18 @@ pub struct Config {
 /// Required fields, retrieved from the app's Cargo.toml
 #[derive(Debug)]
 pub struct PackageConfig {
-    pub name: String, /// Cargo.Toml package.name
-    pub app_manifest: String, /// app manifest filename
-    pub arv: String, /// ARV version to target
-    pub target_hardware: Option<String>, /// subdir under the HardwareDefinitions directory tree to use (usually, mt3620_rdb)
-    pub target_definition: Option<String>, /// base of JSON filename to use for the target (usually, sample_appliance)
-    pub extra_files: Option<Vec<Value>>, /// extra files to include in the app package
+    /// Cargo.Toml package.name
+    pub name: String,
+    /// app manifest filename
+    pub app_manifest: String,
+    /// ARV version to target
+    pub arv: String,
+    /// subdir under the HardwareDefinitions directory tree to use (usually, mt3620_rdb)
+    pub target_hardware: Option<String>,
+    /// base of JSON filename to use for the target (usually, sample_appliance)
+    pub target_definition: Option<String>,
+    /// extra files to include in the app package
+    pub extra_files: Option<Vec<Value>>,
 }
 
 /// Parse the app's Cargo.toml, with optional overrides


### PR DESCRIPTION
Rust 1.66.0:  Fix an error about the doc string following the field name, reported only for extra_files.

# Description

Move the doc comment so the new compiler doesn't error out

## Type of change

- Bug fix

# Checklist:

- [X] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [X] I have performed a self-review of my own contribution
- [X] I have provided comments where appropriate
- [X] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [X] I have added/updated license(s) for this project as appropriate
- [X] I have permission to publish this content (in case the content was collaborative)
- [X] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
