### PR TITLE
Fix GUID output to be little-endian

### DIFF
--- a/ParseDeviceLog/parse-devicelog.py
+++ b/ParseDeviceLog/parse-devicelog.py
@@ -178,7 +178,7 @@ class LogParser:
             index += 4
         if param['paramType'] == 'uniqueId':
             value = data[index:index + 16]
-            guid = uuid.UUID(bytes=value)
+            guid = uuid.UUID(bytes_le=value)
             result_string += ("%s" % guid)
             index += 16
         if param['paramType'] == 'unsignedInteger':


### PR DESCRIPTION
# Description

device log output for application id was incorrectly formatted, needed to be little-endian format.

## Type of change

Please delete options that are not relevant.

- Bug fix

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [x] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [x] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
