### PR TITLE
Document configuring an alternative DNS server

### DIFF
--- a/DNSServiceDiscoveryUnicast/README.md
+++ b/DNSServiceDiscoveryUnicast/README.md
@@ -67,6 +67,20 @@ By default, this sample runs over a Wi-Fi connection to the internet. To use Eth
     char networkInterface[] = "wlan0";
     ```
 
+### Configuring your own DNS server
+
+The supplied Docker image uses **bind9**, but the sample code should work with any correctly configured DNS server (including dedicated DNS-SD servers like **Avahi**, or DNS caches like **dnsmasq**).
+
+When configuring the DNS server, you should ensure that the time-to-live (TTL) for returned SRV/PTR records is **non-zero**: records with a TTL of zero are considered to be expiring immediately, and as such the Azure Sphere operating system will not open the firewall for them.
+
+#### dnsmasq example
+
+For example, **dnsmasq** sets a TTL of zero for all its responses as it is primarily a DNS cache - a zero TTL indicates a record should not be cached by downstream clients. To ensure that locally-configured SRV/PTR records have a non-zero TTL, you should modify `dnsmasq.conf` to include:
+
+```
+local-ttl=10 # Or other non-zero value (in seconds)
+```
+
 ## Running the code
 
 To build and run this project, follow the instructions in [Build a sample application](../../BUILD_INSTRUCTIONS.md).


### PR DESCRIPTION
# Description

Add information regarding configuring an alternative DNS server to the DNS Service Discovery (Unicast) project, including the requirement to set a non-zero TTL for SRV/PTR records.

## Type of change

Please delete options that are not relevant.

- Update to existing content

# Checklist:

- [X] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [X] I have performed a self-review of my own contribution
- [X] I have provided comments where appropriate
- [X] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [X] I have added/updated license(s) for this project as appropriate
- [X] I have permission to publish this content (in case the content was collaborative)
- [X] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
