### PR TITLE
Modify sample Rust project and .apppackage extension to support build/deploy/debug in VS Code

### DIFF
--- a/Rust/cargo-azsphere/src/package.rs
+++ b/Rust/cargo-azsphere/src/package.rs
@@ -250,9 +250,9 @@ impl CliSetting {
                 None
             };
 
-        // ${AzureSphereDefaultSDKDir}/Tools_v2/azsphere image-package pack-application --package-directory out/ --destination ${APPNAME}.apppackage --target-api-set ${ARV}
+        // ${AzureSphereDefaultSDKDir}/Tools_v2/azsphere image-package pack-application --package-directory out/ --destination ${APPNAME}.imagepackage --target-api-set ${ARV}
         let azsphere = sdk_path.join("Tools_v2/azsphere");
-        let app_package_name = target_path.join(package_config.name.clone() + ".apppackage");
+        let app_package_name = target_path.join(package_config.name.clone() + ".imagepackage");
         let mut args = vec![
             "image-package",
             "pack-application",

--- a/Rust/cargo-azsphere/src/sideload.rs
+++ b/Rust/cargo-azsphere/src/sideload.rs
@@ -85,10 +85,10 @@ impl CliSetting {
         target_path.push("armv7-unknown-linux-musleabihf");
         target_path.push(build_flavor);
 
-        // ${AzureSphereDefaultSDKDir}/Tools_v2/azsphere image-package pack-application --package-directory out/ --destination ${APPNAME}.apppackage --target-api-set ${ARV}
+        // ${AzureSphereDefaultSDKDir}/Tools_v2/azsphere image-package pack-application --package-directory out/ --destination ${APPNAME}.imagepackage --target-api-set ${ARV}
         let app_package_name = target_path
             .clone()
-            .join(package_config.name + ".apppackage");
+            .join(package_config.name + ".imagepackage");
         let app_package_name = app_package_name.as_os_str().to_str().unwrap();
         let (azsphere, azsphere_args) = util::azsphere_tool_path();
         let mut args: Vec<String> = vec![];

--- a/Rust/rust/README.md
+++ b/Rust/rust/README.md
@@ -25,7 +25,7 @@ Rust is a systems programming language with a focus on performance and safety. T
 
 ## Documentation
 
-> The contributing and quickstart guides requires the use of a Linux machine or a Windows machine runing Windows Subsystem for Linux (WSL).  Ubuntu is preferred.
+> The contributing and quickstart guides requires the use of a Linux machine or a Windows machine running Windows Subsystem for Linux (WSL).  Ubuntu is preferred.
 
 [Quickstart](./docs/quickstart.md)
 

--- a/Rust/rust/README.md
+++ b/Rust/rust/README.md
@@ -36,7 +36,7 @@ Rust is a systems programming language with a focus on performance and safety. T
 ## Building
 
 - Use `cargo build` or `cargo build --release` to compile.
-- Use `cargo azsphere package` in any app directory, to generate the Azure Sphere .imagepackage file
+- Use `cargo azsphere package` in any app directory, to generate the Azure Sphere .imagepackage file.
 - Use `cargo azsphere sideload` in any app directory, to sideload the application onto a device.  Pass "-m" for manual-launch.
 - Use `cargo azsphere debug` in any app directory, to launch gdb and debug the application.
 

--- a/Rust/rust/README.md
+++ b/Rust/rust/README.md
@@ -36,7 +36,7 @@ Rust is a systems programming language with a focus on performance and safety. T
 ## Building
 
 - Use `cargo build` or `cargo build --release` to compile.
-- Use `cargo azsphere package` in any app directory, to generate the Azure Sphere .appackage file
+- Use `cargo azsphere package` in any app directory, to generate the Azure Sphere .imagepackage file
 - Use `cargo azsphere sideload` in any app directory, to sideload the application onto a device.  Pass "-m" for manual-launch.
 - Use `cargo azsphere debug` in any app directory, to launch gdb and debug the application.
 

--- a/Rust/rust/README.md
+++ b/Rust/rust/README.md
@@ -25,7 +25,7 @@ Rust is a systems programming language with a focus on performance and safety. T
 
 ## Documentation
 
-> The contributing and quickstart guides requires the use of a Linux machine or a Windows machine runing Windows Services for Linux (WSL).  Ubuntu is preferred.
+> The contributing and quickstart guides requires the use of a Linux machine or a Windows machine runing Windows Subsystem for Linux (WSL).  Ubuntu is preferred.
 
 [Quickstart](./docs/quickstart.md)
 

--- a/Rust/rust/docs/quickstart.md
+++ b/Rust/rust/docs/quickstart.md
@@ -50,11 +50,11 @@ cd rust/samples/HelloWorld/hello_world_high_level_app
 
     > cargo build
 
-1. Build the app package:
+1. Build the image package:
 
     > cargo azsphere package
 
-1. Deploy the app package onto the device.
+1. Deploy the image package onto the device.
 
     > cargo azsphere sideload -m
 
@@ -80,6 +80,24 @@ cd rust/samples/HelloWorld/hello_world_high_level_app
     ```
 
     The device's led light should also blink on and off in 1 second cycles.
+
+## Build, Debug and Deploy using Visual Studio Code
+
+1. Navigate to one of the examples in the `samples` directory from the command line:
+
+```bash
+cd rust/samples/HelloWorld/hello_world_high_level_app
+```
+
+1. Open Visual Studio Code:
+
+```bash
+code .
+```
+
+1. Set `program` to the executable's full path inside the configuration in `.vscode/launch.json`. The executable's path will be located at `rust/target/armv7-unknown-linux-musleabihf/debug/hello_world_high_level_app`. 
+
+1. Press `F5` to build, deploy and run the application. If you set any breakpoints before pressing `F5`, you will be able to debug the code.
 
 ## Viewing documentation
 

--- a/Rust/rust/docs/quickstart.md
+++ b/Rust/rust/docs/quickstart.md
@@ -95,8 +95,6 @@ cd rust/samples/HelloWorld/hello_world_high_level_app
 code .
 ```
 
-1. Set `program` to the executable's full path inside the configuration in `.vscode/launch.json`. The executable's path will be located at `rust/target/armv7-unknown-linux-musleabihf/debug/hello_world_high_level_app`. 
-
 1. Press `F5` to build, deploy and run the application. If you set any breakpoints before pressing `F5`, you will be able to debug the code.
 
 ## Viewing documentation

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Launch Azure Sphere App",
             "type": "azurespheredbg",
             "request": "launch",
-            "program": "${workspaceFolder}/armv7-unknown-linux-musleabihf/debug/${workspaceFolderBasename}",
+            "program": "${workspaceFolder}/out/armv7-unknown-linux-musleabihf/debug/${workspaceFolderBasename}",
             "args": [],
             "stopAtEntry": false,
             "environment": [],

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
@@ -8,6 +8,7 @@
             "name": "Launch Azure Sphere App",
             "type": "azurespheredbg",
             "request": "launch",
+            "program": "${workspaceFolder}/../../../target/armv7-unknown-linux-musleabihf/debug/${workspaceFolderBasename}",
             "args": [],
             "stopAtEntry": false,
             "environment": [],

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Launch Azure Sphere App",
             "type": "azurespheredbg",
             "request": "launch",
-            "program": "${workspaceFolder}/../../../target/armv7-unknown-linux-musleabihf/debug/${workspaceFolderBasename}",
+            "program": "${workspaceFolder}/armv7-unknown-linux-musleabihf/debug/${workspaceFolderBasename}",
             "args": [],
             "stopAtEntry": false,
             "environment": [],

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Azure Sphere App",
+            "type": "azurespheredbg",
+            "request": "launch",
+            "args": [],
+            "stopAtEntry": false,
+            "environment": [],
+            "externalConsole": true,
+            "partnerComponents": [],
+            "MIMode": "gdb",
+            "preLaunchTask": "rust: compile"
+        }
+    ]
+}

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/settings.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "AzureSphere.Activate": true
+}

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"command": "cargo",
-			"args": ["build"],
+			"args": ["build", "--target-dir", "."],
 			"problemMatcher": [
 				"$rustc",
 				"$rust-panic"
@@ -18,6 +18,11 @@
 				"$rustc",
 				"$rust-panic"
 			],
+			"options": {
+				"env": {
+					"CARGO_TARGET_DIR": "${workspaceFolder}"
+				}
+			},
 			"group": "build",
 			"label": "rust: cargo azsphere package"
 		},

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"command": "cargo",
+			"args": ["build"],
+			"problemMatcher": [
+				"$rustc",
+				"$rust-panic"
+			],
+			"group": "build",
+			"label": "rust: cargo build"
+		},
+        {
+			"command": "cargo",
+            "args": ["azsphere", "package"],
+			"problemMatcher": [
+				"$rustc",
+				"$rust-panic"
+			],
+			"group": "build",
+			"label": "rust: cargo azsphere package"
+		},
+        {
+            "dependsOn": ["rust: cargo build", "rust: cargo azsphere package"],
+            "dependsOrder": "sequence",
+            "group": "build",
+            "label": "rust: compile"
+        }
+	]
+}

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
@@ -11,9 +11,9 @@
 			"group": "build",
 			"label": "rust: cargo build"
 		},
-        	{
+		{
 			"command": "cargo",
-            		"args": ["azsphere", "package"],
+			"args": ["azsphere", "package"],
 			"problemMatcher": [
 				"$rustc",
 				"$rust-panic"
@@ -28,10 +28,10 @@
 			"label": "rust: cargo azsphere package"
 		},
 		{
-		    "dependsOn": ["rust: cargo build", "rust: cargo azsphere package"],
-		    "dependsOrder": "sequence",
-		    "group": "build",
-		    "label": "rust: compile"
+			"dependsOn": ["rust: cargo build", "rust: cargo azsphere package"],
+		    	"dependsOrder": "sequence",
+		    	"group": "build",
+		    	"label": "rust: compile"
 		}
 	]
 }

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"command": "cargo",
-			"args": ["build", "--target-dir", "."],
+			"args": ["build", "--target-dir", "${workspaceFolder}/out"],
 			"problemMatcher": [
 				"$rustc",
 				"$rust-panic"
@@ -20,7 +20,8 @@
 			],
 			"options": {
 				"env": {
-					"CARGO_TARGET_DIR": "${workspaceFolder}"
+					"CARGO_MANIFEST_DIR": "${workspaceFolder}",
+					"CARGO_TARGET_DIR": "${workspaceFolder}/out"
 				}
 			},
 			"group": "build",


### PR DESCRIPTION
# Description
- `cargo azsphere package` will create an Azure Sphere .imagepackage instead of an .apppackage.
-  `cargo azsphere sideload` will sideload the .imagepackage onto a device.
- Modify [sample Rust project](https://github.com/Azure/azure-sphere-gallery/tree/main/Rust/rust/samples/HelloWorld/hello_world_high_level_app) so VS Code supports build/deploy/debug.

## Type of change
- Update to existing content

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [ ] I have provided comments where appropriate
- [ ] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [ ] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source

The items that remained unchecked are N/A to these changes.