### PR TITLE
ARV 16 and update to latest bindgen

### DIFF
--- a/Rust/rust/.cargo/config
+++ b/Rust/rust/.cargo/config
@@ -1,10 +1,10 @@
 [env]
-AZURE_SPHERE_ARV = "15"
+AZURE_SPHERE_ARV = "16"
 AZURE_SPHERE_TARGET_HARDWARE="mt3620_rdb"
 AZURE_SPHERE_TARGET_DEFINITION="sample_appliance"
 
 [target.armv7-unknown-linux-musleabihf]
-linker = "/opt/azurespheresdk/Sysroots/15/tools/sysroots/x86_64-pokysdk-linux/usr/bin/arm-poky-linux-musleabi/arm-poky-linux-musleabi-gcc"
+linker = "/opt/azurespheresdk/Sysroots/16/tools/sysroots/x86_64-pokysdk-linux/usr/bin/arm-poky-linux-musleabi/arm-poky-linux-musleabi-gcc"
 rustflags = ["-C", "link-arg=-Wl,-Bdynamic"]
 
 [build]

--- a/Rust/rust/azure-sphere/azure-sphere-sys/Cargo.toml
+++ b/Rust/rust/azure-sphere/azure-sphere-sys/Cargo.toml
@@ -9,5 +9,5 @@ links = "azure-sphere"
 libc = { version = "0.2", default-features = false }
 
 [build-dependencies]
-bindgen = { version = "0.54", default-features = false }
+bindgen = { version = "0.66.1", default-features = false }
 cc = "1.0"

--- a/Rust/rust/azure-sphere/src/applibs/applications.rs
+++ b/Rust/rust/azure-sphere/src/applibs/applications.rs
@@ -6,17 +6,17 @@ use azure_sphere_sys::applibs::static_inline_helpers;
 use std::io::Error;
 
 /// Gets the total memory usage of your high-level application in kibibytes. This is the total physical memory usage of your app on the system, including kernel allocations (such as buffers for sockets) on behalf of your app or the debugging server, returned as a raw value (in KiB). Values returned are approximate and may vary across operating system versions.
-pub fn total_memory_usage() -> libc::c_uint {
+pub fn total_memory_usage() -> usize {
     return unsafe { static_inline_helpers::Applications_GetTotalMemoryUsageInKB_inline() };
 }
 
 /// Gets the user-mode memory usage of your high-level application in kibibytes. This is the amount of physical memory used directly by your app, the memory used by any libraries on its behalf (also referred to as anon allocations), and memory used by the debugging server, returned as a raw value (in KiB). Values returned are approximate and may vary across operating system versions.
-pub fn user_mode_memory_usage() -> libc::c_uint {
+pub fn user_mode_memory_usage() -> usize {
     return unsafe { static_inline_helpers::Applications_GetUserModeMemoryUsageInKB_inline() };
 }
 
 /// Gets the peak user-mode memory usage of your high-level application in kibibytes. This is the maximum amount of user memory used in the current session. It is returned as a raw value (in KiB). Values returned are approximate and may vary across operating system versions.
-pub fn peak_user_mode_memory_usage() -> libc::c_uint {
+pub fn peak_user_mode_memory_usage() -> usize {
     return unsafe { static_inline_helpers::Applications_GetPeakUserModeMemoryUsageInKB_inline() };
 }
 

--- a/Rust/rust/azure-sphere/src/applibs/certstore.rs
+++ b/Rust/rust/azure-sphere/src/applibs/certstore.rs
@@ -54,9 +54,9 @@ pub fn install_client_certificate<P: AsRef<OsStr>>(
         certstore::CertStore_InstallClientCertificate(
             identifier,
             cert_blob.as_ptr(),
-            cert_blob.len() as u32,
+            cert_blob.len(),
             private_key_blob.as_ptr(),
-            private_key_blob.len() as u32,
+            private_key_blob.len(),
             private_key_password.as_ptr(),
         )
     };
@@ -80,7 +80,7 @@ pub fn install_root_ca_certificate<P: AsRef<OsStr>>(
         certstore::CertStore_InstallRootCACertificate(
             identifier,
             cert_blob.as_ptr(),
-            cert_blob.len() as u32,
+            cert_blob.len(),
         )
     };
     if result == -1 {
@@ -91,21 +91,21 @@ pub fn install_root_ca_certificate<P: AsRef<OsStr>>(
 }
 
 /// Gets the number of certificates installed on the device.
-pub fn get_certificate_count() -> Result<u32, std::io::Error> {
+pub fn get_certificate_count() -> Result<usize, std::io::Error> {
     let result = unsafe { certstore::CertStore_GetCertificateCount() };
     if result < 0 {
         Err(Error::last_os_error())
     } else {
-        Ok(result as u32)
+        Ok(result as usize)
     }
 }
 
-fn get_certificate_identifer_at(index: u32) -> Result<OsString, std::io::Error> {
+fn get_certificate_identifer_at(index: usize) -> Result<OsString, std::io::Error> {
     unsafe {
         let mut identifier = certstore::CertStore_Identifier {
             identifier: [0u8; 17],
         };
-        let result = certstore::CertStore_GetCertificateIdentifierAt(index as u32, &mut identifier);
+        let result = certstore::CertStore_GetCertificateIdentifierAt(index, &mut identifier);
         if result == -1 {
             Err(Error::last_os_error())
         } else {
@@ -116,7 +116,7 @@ fn get_certificate_identifer_at(index: u32) -> Result<OsString, std::io::Error> 
 }
 
 /// Gets the ID of the certificate at the specified index.
-pub fn get_certificate_at(index: u32) -> Result<Certificate, std::io::Error> {
+pub fn get_certificate_at(index: usize) -> Result<Certificate, std::io::Error> {
     let identifier = get_certificate_identifer_at(index)?;
     Ok(Certificate { identifier })
 }
@@ -180,7 +180,7 @@ impl Certificate {
 /// Iterate through the device's certificate store
 #[derive(Clone, Debug)]
 pub struct Certificates {
-    curr: u32,
+    curr: usize,
 }
 
 impl Iterator for Certificates {

--- a/Rust/rust/azure-sphere/src/applibs/eventloop_timer_utilities.rs
+++ b/Rust/rust/azure-sphere/src/applibs/eventloop_timer_utilities.rs
@@ -46,11 +46,13 @@ impl EventLoopTimer {
             Some(t) => static_inline_helpers::timespec {
                 tv_sec: t.as_secs() as i64,
                 tv_nsec: t.subsec_nanos() as libc::c_long,
+                _bitfield_align_1: [],
                 _bitfield_1: static_inline_helpers::timespec::new_bitfield_1(),
             },
             None => static_inline_helpers::timespec {
                 tv_sec: 0,
                 tv_nsec: 0,
+                _bitfield_align_1: [],
                 _bitfield_1: static_inline_helpers::timespec::new_bitfield_1(),
             },
         };
@@ -58,11 +60,13 @@ impl EventLoopTimer {
             Some(t) => static_inline_helpers::timespec {
                 tv_sec: t.as_secs() as i64,
                 tv_nsec: t.subsec_nanos() as libc::c_long,
+                _bitfield_align_1: [],
                 _bitfield_1: static_inline_helpers::timespec::new_bitfield_1(),
             },
             None => static_inline_helpers::timespec {
                 tv_sec: 0,
                 tv_nsec: 0,
+                _bitfield_align_1: [],
                 _bitfield_1: static_inline_helpers::timespec::new_bitfield_1(),
             },
         };

--- a/Rust/rust/azure-sphere/src/applibs/i2c.rs
+++ b/Rust/rust/azure-sphere/src/applibs/i2c.rs
@@ -55,14 +55,9 @@ impl I2CMaster {
         &self,
         device_address: DeviceAddress,
         buffer: &mut [u8],
-    ) -> Result<i32, std::io::Error> {
+    ) -> Result<isize, std::io::Error> {
         let read_bytes_size = unsafe {
-            i2c::I2CMaster_Read(
-                self.fd,
-                device_address,
-                buffer.as_ptr() as _,
-                buffer.len() as u32,
-            )
+            i2c::I2CMaster_Read(self.fd, device_address, buffer.as_ptr() as _, buffer.len())
         };
 
         if read_bytes_size == -1 {
@@ -77,14 +72,9 @@ impl I2CMaster {
         &self,
         device_address: DeviceAddress,
         buffer: &[u8],
-    ) -> Result<i32, std::io::Error> {
+    ) -> Result<isize, std::io::Error> {
         let bytes_written = unsafe {
-            i2c::I2CMaster_Write(
-                self.fd,
-                device_address,
-                buffer.as_ptr() as _,
-                buffer.len() as u32,
-            )
+            i2c::I2CMaster_Write(self.fd, device_address, buffer.as_ptr() as _, buffer.len())
         };
 
         if bytes_written == -1 {
@@ -105,15 +95,15 @@ impl I2CMaster {
         device_address: DeviceAddress,
         write_buffer: &[u8],
         read_buffer: &mut [u8],
-    ) -> Result<i32, std::io::Error> {
+    ) -> Result<isize, std::io::Error> {
         let total_bytes = unsafe {
             i2c::I2CMaster_WriteThenRead(
                 self.fd,
                 device_address,
                 write_buffer.as_ptr() as _,
-                write_buffer.len() as u32,
+                write_buffer.len(),
                 read_buffer.as_ptr() as _,
-                read_buffer.len() as u32,
+                read_buffer.len(),
             )
         };
 

--- a/Rust/rust/azure-sphere/src/applibs/networking.rs
+++ b/Rust/rust/azure-sphere/src/applibs/networking.rs
@@ -83,12 +83,12 @@ pub fn is_networking_ready() -> Result<bool, std::io::Error> {
 
 /// Gets the number of network interfaces in an Azure Sphere device.
 /// The number of interfaces in the system will not change within a boot cycle.
-pub fn interface_count() -> Result<u32, std::io::Error> {
+pub fn interface_count() -> Result<usize, std::io::Error> {
     let count = unsafe { networking::Networking_GetInterfaceCount() };
     if count == -1 {
         Err(Error::last_os_error())
     } else {
-        Ok(count as usize as u32)
+        Ok(count as usize)
     }
 }
 
@@ -403,7 +403,7 @@ impl IpConfig {
             networking::Networking_IpConfig_EnableCustomDns(
                 &mut self.ipconfig,
                 dns_server_address.as_ptr(),
-                dns_server_address.len() as u32,
+                dns_server_address.len() as usize,
             )
         };
         if r == -1 {
@@ -515,7 +515,7 @@ impl DhcpServerConfig {
             networking::Networking_DhcpServerConfig_SetNtpServerAddresses(
                 &mut self.config,
                 ntp_server_addresses.as_ptr(),
-                ntp_server_addresses.len() as u32,
+                ntp_server_addresses.len(),
             )
         };
         if result == 0 {
@@ -562,7 +562,7 @@ pub fn set_hardware_address(
         static_inline_helpers::Networking_SetHardwareAddress_inline(
             network_interface_name.as_ptr(),
             hardware_address.as_ptr(),
-            hardware_address.len() as u32,
+            hardware_address.len(),
         )
     };
     if result == 0 {

--- a/Rust/rust/azure-sphere/src/applibs/spi.rs
+++ b/Rust/rust/azure-sphere/src/applibs/spi.rs
@@ -97,14 +97,14 @@ impl SPIMaster {
         &self,
         write_buffer: &[u8],
         read_buffer: &mut [u8],
-    ) -> Result<i32, std::io::Error> {
+    ) -> Result<isize, std::io::Error> {
         let total_bytes = unsafe {
             static_inline_helpers::SPIMaster_WriteThenRead_inline(
                 self.fd,
                 write_buffer.as_ptr() as _,
-                write_buffer.len() as u32,
+                write_buffer.len(),
                 read_buffer.as_ptr() as _,
-                read_buffer.len() as u32,
+                read_buffer.len(),
             )
         };
 
@@ -121,7 +121,7 @@ impl SPIMaster {
     pub fn transfer_sequential<'a, 'b>(
         &self,
         transfers: &mut [SPIMasterTransfer<'a, 'b>],
-    ) -> Result<i32, std::io::Error> {
+    ) -> Result<isize, std::io::Error> {
         // Initialize a template SPIMaster_Transfer
         let mut t_template = static_inline_helpers::SPIMaster_Transfer {
             z__magicAndVersion: 0,
@@ -144,9 +144,9 @@ impl SPIMaster {
             t_template.writeData = t.write_data.as_ptr();
             t_template.readData = t.read_data.as_mut_ptr();
             t_template.length = if t.write_data.len() == 0 {
-                t.read_data.len() as static_inline_helpers::size_t
+                t.read_data.len() as libc::size_t
             } else {
-                min(t.write_data.len(), t.read_data.len()) as static_inline_helpers::size_t
+                min(t.write_data.len(), t.read_data.len()) as libc::size_t
             };
             v.push(t_template)
         }
@@ -155,7 +155,7 @@ impl SPIMaster {
             static_inline_helpers::SPIMaster_TransferSequential_inline(
                 self.fd,
                 v.as_mut_ptr(),
-                v.len() as u32,
+                v.len(),
             )
         };
         if total_bytes == -1 {

--- a/Rust/rust/azure-sphere/src/applibs/wificonfig.rs
+++ b/Rust/rust/azure-sphere/src/applibs/wificonfig.rs
@@ -242,13 +242,13 @@ pub fn forget_all_networks() -> Result<(), std::io::Error> {
 
 /// Gets the number of stored Wi-Fi networks on the device. This function is not thread safe.
 /// The application manifest must include the WifiConfig capability.
-pub fn stored_network_count() -> Result<u32, std::io::Error> {
+pub fn stored_network_count() -> Result<usize, std::io::Error> {
     let result = unsafe { wificonfig::WifiConfig_GetStoredNetworkCount() };
     if result < 0 {
         Err(Error::last_os_error())
     } else {
         // Convert from ssize_t to u32 now that the failure value of -1 has been handled
-        Ok(result as u32)
+        Ok(result as usize)
     }
 }
 
@@ -337,12 +337,12 @@ pub fn connected_network_id() -> Result<u32, std::io::Error> {
 /// - This is a blocking call
 ///
 /// The application manifest must include the WifiConfig capability.
-pub fn trigger_scan_and_get_scanned_network_count() -> Result<u32, std::io::Error> {
+pub fn trigger_scan_and_get_scanned_network_count() -> Result<usize, std::io::Error> {
     let count = unsafe { wificonfig::WifiConfig_TriggerScanAndGetScannedNetworkCount() };
     if count < 0 {
         Err(Error::last_os_error())
     } else {
-        Ok(count as u32)
+        Ok(count as usize)
     }
 }
 
@@ -409,7 +409,7 @@ pub fn set_ssid(network_id: u32, ssid: &[u8]) -> Result<(), std::io::Error> {
         static_inline_helpers::WifiConfig_SetSSID_inline(
             network_id as i32,
             ssid.as_ptr(),
-            ssid.len() as u32,
+            ssid.len(),
         )
     };
     if result == -1 {
@@ -490,11 +490,7 @@ pub fn reload_config() -> Result<(), std::io::Error> {
 /// The application manifest must include the WifiConfig capability.
 pub fn set_psk(network_id: u32, psk: &[u8]) -> Result<(), std::io::Error> {
     let result = unsafe {
-        static_inline_helpers::WifiConfig_SetPSK_inline(
-            network_id as i32,
-            psk.as_ptr(),
-            psk.len() as u32,
-        )
+        static_inline_helpers::WifiConfig_SetPSK_inline(network_id as i32, psk.as_ptr(), psk.len())
     };
     if result == -1 {
         Err(Error::last_os_error())


### PR DESCRIPTION
# Description

Update the ARV to 16, for the 23.05 SDK.  Also updates bindgen version to latest, as the build was triggering warnings about soon-to-be-deprecated codegen from the old one.

WolfCrypt wrappers will come in a future PR.

## Type of change

- Update to existing content

# Checklist:

- [X] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [X] I have performed a self-review of my own contribution
- [X] I have provided comments where appropriate
- [X] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [X] I have added/updated license(s) for this project as appropriate
- [X] I have permission to publish this content (in case the content was collaborative)
- [X] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
