### PR TITLE
Update DeviceTenantFinder to .NET Core 6.0, add prompt for Device Id

### DIFF
--- a/DeviceTenantFinder/Src/DeviceTenantFinder/DeviceTenantFinder.csproj
+++ b/DeviceTenantFinder/Src/DeviceTenantFinder/DeviceTenantFinder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DeviceTenantFinder/Src/DeviceTenantFinder/Program.cs
+++ b/DeviceTenantFinder/Src/DeviceTenantFinder/Program.cs
@@ -37,13 +37,18 @@ namespace DeviceTenantFinder
 
         public static async Task<int> Main(string[] args)
         {
+            string deviceId = string.Empty;
             if (args.Count() != 1)
             {
-                Console.WriteLine("App requires a device id on the command line");
-                return -1;
+                Console.Write("Enter a device id >");
+                deviceId = Console.ReadLine();
+            }
+            else
+            {
+                deviceId = args[0];
             }
 
-            if (args[0].Length != 128)
+            if (deviceId.Length != 128)
             {
                 Console.WriteLine("Device Id Length is expected to be 128 characters, try again");
                 return -1;
@@ -85,7 +90,7 @@ namespace DeviceTenantFinder
                 Devices devices = JsonSerializer.Deserialize<Devices>(result);
                 foreach (Item item in devices.Items)
                 {
-                    if (item.DeviceId.ToLower() == args[0].ToLower())
+                    if (item.DeviceId.ToLower() == deviceId.ToLower())
                     {
                         deviceFound = true;
                         tenantId = tenant.Id;
@@ -105,12 +110,11 @@ namespace DeviceTenantFinder
                 return -1;
             }
 
-            Console.WriteLine($"Device Found   : {args[0]}");
+            Console.WriteLine($"Device Found   : {deviceId}");
             Console.WriteLine($"Tenant Id      : {tenantId}");
             Console.WriteLine($"Tenant Name    : {tenantName}");
             Console.WriteLine($"Product Id     : {productId}");
             Console.WriteLine($"Device Group Id: {deviceGroupId}");
-
 
             return 0;
         }


### PR DESCRIPTION
# Description

Update project from .NET Core 3.1 to .NET Core 6.0 - also add a prompt for device id if one isn't provided on the command line.

## Type of change

Please delete options that are not relevant.

- Update to existing content

# Checklist:

- [x] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [x] I have performed a self-review of my own contribution
- [x] I have provided comments where appropriate
- [x] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [x] I have added/updated license(s) for this project as appropriate
- [x] I have permission to publish this content (in case the content was collaborative)
- [x] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
