### PR TITLE
Barrybo/rust1.72

### DIFF
--- a/Rust/rust/Cargo.toml
+++ b/Rust/rust/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "samples/allapis",

--- a/Rust/rust/azure-sphere/Cargo.toml
+++ b/Rust/rust/azure-sphere/Cargo.toml
@@ -2,7 +2,7 @@
 name = "azure-sphere"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere-sys = { path = "./azure-sphere-sys", version = "0.1" }

--- a/Rust/rust/azure-sphere/azure-sphere-sys/Cargo.toml
+++ b/Rust/rust/azure-sphere/azure-sphere-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "azure-sphere-sys"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 links = "azure-sphere"
 
 [dependencies]

--- a/Rust/rust/azure-sphere/azure-sphere-sys/Cargo.toml
+++ b/Rust/rust/azure-sphere/azure-sphere-sys/Cargo.toml
@@ -9,5 +9,5 @@ links = "azure-sphere"
 libc = { version = "0.2", default-features = false }
 
 [build-dependencies]
-bindgen = { version = "0.66.1", default-features = false }
+bindgen = { version = "0.68.1", default-features = false }
 cc = "1.0"

--- a/Rust/rust/azure-sphere/azure-sphere-sys/build.rs
+++ b/Rust/rust/azure-sphere/azure-sphere-sys/build.rs
@@ -138,9 +138,9 @@ fn main() {
     let patched_libc = patched_libs_path.join("libc.so");
     patch_lib(libc.as_path(), patched_libc.as_path()).unwrap();
 
-    println!("cargo:rustc-link-lib=c");
-    println!("cargo:rustc-link-lib=applibs");
-    println!("cargo:rustc-link-lib=tlsutils");
+    //println!("cargo:rustc-link-lib=dylib:c");
+    //println!("cargo:rustc-link-lib=dylib:applibs");
+    //println!("cargo:rustc-link-lib=dylib:tlsutils");
     println!(
         "cargo:rustc-link-search={}",
         patched_libs_path.as_path().to_str().unwrap()

--- a/Rust/rust/azure-sphere/azure-sphere-sys/src/lib.rs
+++ b/Rust/rust/azure-sphere/azure-sphere-sys/src/lib.rs
@@ -7,6 +7,11 @@ Licensed under the MIT License. */
 #![allow(dead_code)]
 #![no_std]
 
+#[link(name = "applibs", kind = "dylib")]
+#[link(name = "tlsutils", kind = "dylib")]
+#[link(name = "c", kind = "dylib")]
+extern "C" {}
+
 macro_rules! sys_mod {
     ($name:ident) => {
         pub mod $name {

--- a/Rust/rust/azure-sphere/src/applibs/certstore.rs
+++ b/Rust/rust/azure-sphere/src/applibs/certstore.rs
@@ -33,7 +33,7 @@ fn convert_tm_to_datetime(tm: &mut static_inline_helpers::tm) -> DateTime<Utc> {
     let naive =
         NaiveDateTime::from_timestamp_opt(timestamp / 1000, (timestamp % 1000) as u32 * 1_000_000)
             .unwrap();
-    DateTime::<Utc>::from_utc(naive, Utc)
+    DateTime::from_naive_utc_and_offset(naive, Utc)
 }
 
 /// Installs a client certificate that consists of a public certificate and a private key with the specified ID. The ID can then be used to refer to the certificate in other functions. If any type of certificate is already installed with the same ID, it will be replaced with the new certificate.

--- a/Rust/rust/azure-sphere/src/applibs/networking.rs
+++ b/Rust/rust/azure-sphere/src/applibs/networking.rs
@@ -224,7 +224,7 @@ fn convert_tm_to_datetime(tm: &mut networking::tm) -> DateTime<Utc> {
     let naive =
         NaiveDateTime::from_timestamp_opt(timestamp / 1000, (timestamp % 1000) as u32 * 1_000_000)
             .unwrap();
-    DateTime::<Utc>::from_utc(naive, Utc)
+    DateTime::from_naive_utc_and_offset(naive, Utc)
 }
 
 /// Gets the NTP server last used to successfully sync the device. The [`is_networking_ready`] API can be used to determine when this API can be called.

--- a/Rust/rust/samples/ADC/adc_high_level_app/Cargo.toml
+++ b/Rust/rust/samples/ADC/adc_high_level_app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "adc_high_level_app"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere = { path = "../../../azure-sphere", version = "0.1" }

--- a/Rust/rust/samples/CertStore/cert_store_high_level_app/Cargo.toml
+++ b/Rust/rust/samples/CertStore/cert_store_high_level_app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cert_store_high_level_app"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere = { path = "../../../azure-sphere", version = "0.1" }

--- a/Rust/rust/samples/CustomNTP/custom_ntp_high_level_app/Cargo.toml
+++ b/Rust/rust/samples/CustomNTP/custom_ntp_high_level_app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "custom_ntp_high_level_app"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere = { path = "../../../azure-sphere", version = "0.1" }

--- a/Rust/rust/samples/DHCP/Cargo.toml
+++ b/Rust/rust/samples/DHCP/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dhcp_high_level_app"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere = { path = "../../azure-sphere", version = "0.1" }

--- a/Rust/rust/samples/GPIO/gpio_high_level_app/Cargo.toml
+++ b/Rust/rust/samples/GPIO/gpio_high_level_app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gpio_high_level_app"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere = { path = "../../../azure-sphere", version = "0.1" }

--- a/Rust/rust/samples/HelloWorld/hello_world_high_level_app/Cargo.toml
+++ b/Rust/rust/samples/HelloWorld/hello_world_high_level_app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello_world_high_level_app"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere = { path = "../../../azure-sphere", version = "0.1" }

--- a/Rust/rust/samples/allapis/Cargo.toml
+++ b/Rust/rust/samples/allapis/Cargo.toml
@@ -2,7 +2,7 @@
 name = "allapis"
 version = "0.1.0"
 authors = ["Microsoft"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 azure-sphere = { path = "../../azure-sphere", version = "0.1" }

--- a/Rust/rust/samples/allapis/Cargo.toml
+++ b/Rust/rust/samples/allapis/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 azure-sphere = { path = "../../azure-sphere", version = "0.1" }
 nullable-result = { version = "0.7", default-features = false }
-curl = { git="https://github.com/BarryBo/curl-rust.git", branch="AzureSphere", version="0.4.44", features=["static-ssl"] }
+curl = { git="https://github.com/BarryBo/curl-rust.git", branch="AzureSphere", features=["static-ssl"] }
 azure_iot_hub = "0.4.0" # see https://github.com/Azure/azure-sdk-for-rust and https://crates.io/crates/azure_sdk_for_rust
 
 [package.metadata.azsphere]


### PR DESCRIPTION
# Description

Update to Rust 1.72.1.  There was a deprecated API, and a breaking change to how external .so files are added to the linker line.  See https://github.com/rust-lang/rust/pull/111698/.

## Type of change

- Update to existing content

# Checklist:

- [X] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [X] I have performed a self-review of my own contribution
- [X] I have provided comments where appropriate
- [X] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [X] I have added/updated license(s) for this project as appropriate
- [X] I have permission to publish this content (in case the content was collaborative)
- [X] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
