### PR TITLE
Add documentation for client cert chain in HTTPS Mutual Auth sample

### DIFF
--- a/HTTPS_MutualAuth/Azsphere/CMakeLists.txt
+++ b/HTTPS_MutualAuth/Azsphere/CMakeLists.txt
@@ -6,6 +6,6 @@ cmake_minimum_required(VERSION 3.20)
 project(HTTPS_MutualAuth C)
 
 add_executable(${PROJECT_NAME} main.c eventloop_timer_utilities.c)
-target_link_libraries(${PROJECT_NAME} applibs gcc_s c curl wolfssl)
+target_link_libraries(${PROJECT_NAME} applibs gcc_s c curl)
 
 azsphere_target_add_image_package(${PROJECT_NAME} RESOURCE_FILES "certs/ca-bundle.pem" "certs/device-cert.pem" "certs/device-key.pem")

--- a/HTTPS_MutualAuth/Azsphere/CMakeLists.txt
+++ b/HTTPS_MutualAuth/Azsphere/CMakeLists.txt
@@ -6,6 +6,6 @@ cmake_minimum_required(VERSION 3.20)
 project(HTTPS_MutualAuth C)
 
 add_executable(${PROJECT_NAME} main.c eventloop_timer_utilities.c)
-target_link_libraries(${PROJECT_NAME} applibs gcc_s c curl)
+target_link_libraries(${PROJECT_NAME} applibs gcc_s c curl wolfssl)
 
 azsphere_target_add_image_package(${PROJECT_NAME} RESOURCE_FILES "certs/ca-bundle.pem" "certs/device-cert.pem" "certs/device-key.pem")

--- a/HTTPS_MutualAuth/Azsphere/main.c
+++ b/HTTPS_MutualAuth/Azsphere/main.c
@@ -303,6 +303,11 @@ static void PerformWebPageDownload(void)
         goto cleanupLabel;
     }
     
+    if ((res = curl_easy_setopt(curlHandle, CURLOPT_SSLCERT, clientCertPath)) != CURLE_OK) {
+        LogCurlError("curl_easy_setopt CURLOPT_SSLCERT", res);
+        goto cleanupLabel;
+    }
+    
     clientKeyPath= Storage_GetAbsolutePathInImagePackage("certs/device-key.pem");
     if (clientKeyPath == NULL) {
         Log_Debug("The client key path could not be resolved: errno=%d (%s)\n", errno,
@@ -310,11 +315,20 @@ static void PerformWebPageDownload(void)
         goto cleanupLabel;
     }
 
-    curl_easy_setopt(curlHandle, CURLOPT_SSLCERT, clientCertPath);
-    curl_easy_setopt(curlHandle, CURLOPT_SSLKEY, clientKeyPath);
+    if ((res = curl_easy_setopt(curlHandle, CURLOPT_SSLKEY, clientKeyPath)) != CURLE_OK) {
+        LogCurlError("curl_easy_setopt CURLOPT_SSLKEY", res);
+        goto cleanupLabel;
+    }
 
-    curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYHOST, 1L);
+    if ((res = curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYPEER, 1L)) != CURLE_OK) {
+        LogCurlError("curl_easy_setopt CURLOPT_SSL_VERIFYPEER", res);
+        goto cleanupLabel;
+    }
+
+    if ((res = curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYHOST, 1L)) != CURLE_OK) {
+        LogCurlError("curl_easy_setopt CURLOPT_SSL_VERIFYHOST", res);
+        goto cleanupLabel;
+    }
 
     // Let cURL follow any HTTP 3xx redirects.
     // Important: Any redirection to different domain names requires that domain name to be added to

--- a/HTTPS_MutualAuth/README.md
+++ b/HTTPS_MutualAuth/README.md
@@ -22,6 +22,7 @@ Please refer to the HTTPS_Curl_Easy sample for detailed setup instructions.
    - `server-certs/server-cert.pem` - the server certificate
    - `server-certs/server-key.pem` - the private key for the server certificate
 
+   If you are using a device certificate _chain_ rather than a single certificate, please refer to the instructions below
 
 1. Launch the server:
    ```
@@ -51,6 +52,67 @@ Please refer to the HTTPS_Curl_Easy sample for detailed setup instructions.
 1. Build and run the project.
 
    In the device output, you should see a successful HTTP request (with a directory listing from the server)
+
+### Using a device certificate chain
+
+Some configurations may require the use of a certificate chain rather than a single device certificate (for example, if the
+device certificate is not signed by the required root authority, but is rather signed by an intermediate authority, which has itself
+been signed by the root authority required by the server).
+
+In this case, you cannot use the `curl_easy_setopt(curlHandle, CURLOPT_SSLCERT, clientCertPath);` function to set the client certificate;
+rather, you must use `wolfSSL_CTX_use_certificate_chain_file` from within the SSL context callback:
+
+1. At the top of main.c, add:
+   ```c
+   #include "wolfssl/ssl.h"
+   ```
+
+1. Add the following function somewhere above `PerformWebPageDownload()`:
+   ```c
+   CURLcode wolfssl_ctx_callback(CURL* curlHandle, void* wolfssl_ctx, void* client)
+   {
+      char* clientCertPath= Storage_GetAbsolutePathInImagePackage("certs/device-cert.pem");
+      if (clientCertPath == NULL) {
+         Log_Debug("The client certificate path could not be resolved: errno=%d (%s)\n", errno,
+                     strerror(errno));
+         return CURLE_SSL_CONNECT_ERROR;
+      }
+
+      int r = wolfSSL_CTX_use_certificate_chain_file(wolfssl_ctx, clientCertPath);
+      if (r != WOLFSSL_SUCCESS) {
+         Log_Debug("Error loading cert chain for client\n");
+         return CURLE_SSL_CONNECT_ERROR;
+      }
+
+      return CURLE_OK;
+   }
+   ```
+
+1. In `PerformWebPageDownload()`, remove the lines:
+
+   ```c
+   clientCertPath= Storage_GetAbsolutePathInImagePackage("certs/device-cert.pem");
+   if (clientCertPath == NULL) {
+       Log_Debug("The client certificate path could not be resolved: errno=%d (%s)\n", errno,
+                 strerror(errno));
+       goto cleanupLabel;
+   }
+
+   if ((res = curl_easy_setopt(curlHandle, CURLOPT_SSLCERT, clientCertPath)) != CURLE_OK) {
+       LogCurlError("curl_easy_setopt CURLOPT_SSLCERT", res);
+       goto cleanupLabel;
+   }
+   ```
+
+   and replace them with:
+   
+   ```c
+    if ((res = curl_easy_setopt(curlHandle, CURLOPT_SSL_CTX_FUNCTION, wolfssl_ctx_callback)) != CURLE_OK) {
+        LogCurlError("curl_easy_setopt CURLOPT_SSL_CTX_FUNCTION", res);
+        goto cleanupLabel;
+    }
+   ```
+
 
 ### Generating test certificates
 

--- a/HTTPS_MutualAuth/README.md
+++ b/HTTPS_MutualAuth/README.md
@@ -67,7 +67,7 @@ rather, you must use `wolfSSL_CTX_use_certificate_chain_file` from within the SS
    #include "wolfssl/ssl.h"
    ```
 
-1. In CMakeLists.txt, modofy the `target_link_libraries` to include `wolfssl`:
+1. In CMakeLists.txt, modify the `target_link_libraries` to include `wolfssl`:
    ```cmake
    target_link_libraries(${PROJECT_NAME} applibs gcc_s c curl wolfssl)
    ```

--- a/HTTPS_MutualAuth/README.md
+++ b/HTTPS_MutualAuth/README.md
@@ -67,6 +67,11 @@ rather, you must use `wolfSSL_CTX_use_certificate_chain_file` from within the SS
    #include "wolfssl/ssl.h"
    ```
 
+1. In CMakeLists.txt, modofy the `target_link_libraries` to include `wolfssl`:
+   ```cmake
+   target_link_libraries(${PROJECT_NAME} applibs gcc_s c curl wolfssl)
+   ```
+
 1. Add the following function somewhere above `PerformWebPageDownload()`:
    ```c
    CURLcode wolfssl_ctx_callback(CURL* curlHandle, void* wolfssl_ctx, void* client)

--- a/HTTPS_MutualAuth/make-certs.sh
+++ b/HTTPS_MutualAuth/make-certs.sh
@@ -2,6 +2,17 @@
 
 IP=$1
 
+if [[ -z $IP ]]; then
+    echo "syntax: $0 <ip address or hostname>"
+    exit -1
+fi
+
+echo "Clearing old certs"
+
+rm -v generated-certs/*
+rm -v Azsphere/certs/*
+rm -v server-certs/*
+
 echo "Making cert config for $IP"
 
 sed "s/IP_ADDRESS/$IP/g" certs-config/server.conf.template > certs-config/server.conf
@@ -53,6 +64,8 @@ echo "------------------------------------------------------------------------"
 echo "Signing device cert"
 openssl x509 -req -days 363 -in generated-certs/device.csr -CA generated-certs/rootca-cert.pem -CAkey generated-certs/rootca-key.pem -CAcreateserial -out generated-certs/device-cert.pem
 
-cat generated-certs/rootca-cert.pem generated-certs/intermediate-cert.pem > Azsphere/certs/ca-bundle.pem
-cp generated-certs/device-cert.pem generated-certs/device-key.pem Azsphere/certs/
-cp generated-certs/rootca-cert.pem generated-certs/server-cert.pem generated-certs/server-key.pem server-certs
+echo "Making CA bundle"
+cat generated-certs/rootca-cert.pem generated-certs/intermediate-cert.pem > generated-certs/ca-bundle.pem
+
+cp -v generated-certs/ca-bundle.pem generated-certs/device-cert.pem generated-certs/device-key.pem Azsphere/certs/
+cp -v generated-certs/rootca-cert.pem generated-certs/server-cert.pem generated-certs/server-key.pem server-certs


### PR DESCRIPTION
# Description

Add documentation describing use of a client cert chain in HTTPS Mutual Auth sample

## Type of change

- Update to existing content

# Checklist:

- [X] My content has a file named README.md, which is based on the appropriate readme [template](https://github.com/Azure/azure-sphere-gallery/tree/main/Templates)
- [X] I have performed a self-review of my own contribution
- [X] I have provided comments where appropriate
- [X] I have updated the repository's [README.md](https://github.com/Azure/azure-sphere-gallery/blob/main/README.md) to index this project
- [X] I have added/updated license(s) for this project as appropriate
- [X] I have permission to publish this content (in case the content was collaborative)
- [X] I have verified that my content does not contain sensitive information (PII, Microsoft PI, etc.) and is safe to open source
